### PR TITLE
Limit upload requests to 15 requests per minute

### DIFF
--- a/src/upload-emoji.js
+++ b/src/upload-emoji.js
@@ -7,10 +7,17 @@ import getSlackApiData from './get-slack-api-data';
 
 const NO_OP = function () {};
 
+/**
+ * Throttle requests to no more than 15 per minute to avoid hitting Slack API's
+ * rate limit.
+ *
+ * @see [Slack API rate limit docs](https://api.slack.com/docs/rate-limits#web)
+ */
 const superagentThrottle = new SuperagentThrottle({
   active: true,
   concurrent: 5,
-  rate: Infinity
+  rate: 15,
+  ratePer: 60000,
 });
 
 export default function uploadEmoji (file, callback = NO_OP) {


### PR DESCRIPTION
Slack's web API, which is what handles custom emoji uploads, has a rate limit of [around 20+ per minute](https://api.slack.com/docs/rate-limits#web). This PR is to limit the number of requests to 15 per minute to be safe.

A more robust way to implement this would be to check a response's `Retry-After` header and hold all subsequent requests for the given amount of time. The implementation in this PR is a more quick-and-dirty method of ensuring that the number of requests never reaches the limit in the first place.